### PR TITLE
Fix crash due unitialized memory

### DIFF
--- a/platform/linuxbsd/display_server_x11.h
+++ b/platform/linuxbsd/display_server_x11.h
@@ -101,8 +101,8 @@ class DisplayServerX11 : public DisplayServer {
 	GLManager_X11 *gl_manager = nullptr;
 #endif
 #if defined(VULKAN_ENABLED)
-	VulkanContextX11 *context_vulkan;
-	RenderingDeviceVulkan *rendering_device_vulkan;
+	VulkanContextX11 *context_vulkan = nullptr;
+	RenderingDeviceVulkan *rendering_device_vulkan = nullptr;
 #endif
 
 	struct WindowData {


### PR DESCRIPTION
This fixes crashes from my comments https://github.com/godotengine/godot/pull/44399#issuecomment-746195746

Memory was non initialized and later was used e.g. here
https://github.com/lawnjelly/godot/blob/9f109f25f0b3bc9249b14b4439fe769f2a16af31/platform/linuxbsd/display_server_x11.cpp#L3842-L3847

this memory was only initialized if rendering driver was Vulkan(it works fine in master, because only  Vulkan was available), but when GLES was added, then in some places variables were used without checking if proper rendering driver is used - here unlike at the top, there is check `(rendering_driver == "vulkan") `

https://github.com/lawnjelly/godot/blob/9f109f25f0b3bc9249b14b4439fe769f2a16af31/platform/linuxbsd/display_server_x11.cpp#L880-L884